### PR TITLE
Feature/convexhull

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 ## How to Run
 
 ```sh
+# Install GEOS
+# https://libgeos.org/usage/install/
+brew install geos
+```
+
+```sh
 go mod download
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module makePolygonWithGo
 go 1.20
 
 require github.com/paulmach/go.geojson v1.5.0
+
+require github.com/twpayne/go-geos v0.18.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,7 @@
+github.com/alecthomas/assert/v2 v2.10.0 h1:jjRCHsj6hBJhkmhznrCzoNpbA3zqy0fYiUcYZP/GkPY=
+github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/paulmach/go.geojson v1.5.0 h1:7mhpMK89SQdHFcEGomT7/LuJhwhEgfmpWYVlVmLEdQw=
 github.com/paulmach/go.geojson v1.5.0/go.mod h1:DgdUy2rRVDDVgKqrjMe2vZAHMfhDTrjVKt3LmHIXGbU=
+github.com/twpayne/go-geos v0.18.1 h1:dzUHvkxcJHXTSPDqYBA39M+OE2myyqZO9ytBSMjS370=
+github.com/twpayne/go-geos v0.18.1/go.mod h1:H5qP0wfgtZOl2g+KT0WGKn2z2mr5XPnGbgGlUefaCOM=

--- a/main.go
+++ b/main.go
@@ -361,7 +361,7 @@ func main() {
 	typhoons := []Typhoon{
 		// 実況
 		// calcTyphoonPolygon(22.3, 140.9, 330., 220., 0., 120), // 強風域
-		// calcTyphoonPolygon(22.3, 140.9, 55., 55., 0., 120), // 暴風域
+		calcTyphoonPolygon(22.3, 140.9, 55., 55., 0., 120), // 暴風域
 		// 予報　１２時間後
 		calcTyphoonPolygon(24.9, 139.6, 75., 75., 0., 120), // 予報円
 		// calcTyphoonPolygon(24.9, 139.6, 130., 130., 0., 120), // 暴風警戒域


### PR DESCRIPTION
台風の描画の基本ロジック


1. 台風の円のポリゴンつくる(これは前回までに実装)
1. 🆕 台風の「1つ目と2つ目」、「2つ目と3つ目」...とペアをつくっていき、それぞれに対して凸包(convexhull)を適用
    1. これによって円+円の軌跡(接線)がつくられる
1. 🆕 それぞれのペアをマルチポリゴンとし、GEOSのBuffer(0, 32)で自己交差線を削除
    1. これによって暴風域内部の線が取り除かれた単一のポリゴンとなる
    1. Bufferの第一引数は太さ。今回は太くする必要はないので0
    1. Bufferの第二引数は一つの円を構成する点の個数


<img width="937" alt="image" src="https://github.com/user-attachments/assets/114e7176-832e-42cc-b23f-317ca996d393">
